### PR TITLE
Convert gitlab-source-group/source-multi-yml-use to GitHub Actions

### DIFF
--- a/.github/workflows/source-multi-yml-use.yml
+++ b/.github/workflows/source-multi-yml-use.yml
@@ -1,0 +1,31 @@
+name: gitlab-source-group/source-multi-yml-use
+on:
+  push:
+  workflow_dispatch:
+concurrency:
+  group: "${{ github.ref }}"
+  cancel-in-progress: true
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    container:
+      image: alpine:latest
+    timeout-minutes: 60
+    steps:
+    - uses: actions/checkout@v4.1.0
+      with:
+        fetch-depth: 20
+        lfs: true
+    - run: echo "Building the application..."
+  test:
+    needs: build
+    runs-on: ubuntu-latest
+    container:
+      image: alpine:latest
+    timeout-minutes: 60
+    steps:
+    - uses: actions/checkout@v4.1.0
+      with:
+        fetch-depth: 20
+        lfs: true
+    - run: echo "Running tests..."


### PR DESCRIPTION
Pipeline migrated from [GitLab](https://gitlab.com/gitlab-source-group/source-multi-yml-use) :tada: